### PR TITLE
Add option to ignore the alpha channel

### DIFF
--- a/fbgrab.1.man
+++ b/fbgrab.1.man
@@ -14,6 +14,9 @@ X-windows desktop, as well as framebuffer applications.
 .B -?
 print usage information.
 .TP
+.B -a
+ignore the alpha channel, to support pixel formats like BGR32.
+.TP
 .B -b bitdepth
 the number of bits per pixel used, optional when reading from device.
 .TP

--- a/fbgrab.c
+++ b/fbgrab.c
@@ -431,7 +431,7 @@ int main(int argc, char **argv)
 
     for(;;)
     {
-	optc=getopt(argc, argv, "f:z:w:b:h:l:iC:c:d:s:?v");
+	optc=getopt(argc, argv, "f:z:w:b:h:l:iC:c:d:s:?av");
 	if (optc==-1)
 	    break;
 	switch (optc)

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ FBGrab is a framebuffer screenshot program, capturing the linux frambuffer and c
 ## OPTIONS
        -?     print usage information.
 
+       -a     ignore the alpha channel, to support pixel formats like BGR32.
+
        -b bitdepth
               the number of bits per pixel used, optional  when  reading  from
               device.


### PR DESCRIPTION
On our embedded platform the framebuffer is set up as BGR32, which reports itself identically to BGRA32 in terms of the channel offsets and lengths.

However when using fbgrab out of the box, it results in an entirely transparent image. The actual image is recoverable by removing the alpha channel in post-processing, however we'd rather avoid needing to do that when it can be stripped at the point of capture.

To do this, I added an option to force the ( fb_varinfo.transp.length > 0 ) check to be ignored, causing srcAlpha to be set to -1, and the existing handling to take effect. This involves moving that check out of get_framebufferdata and into main, but otherwise does not change program flow or function signatures at all.

I'm happy to change the command line letter assignment if it's not to your taste.

While I'm here, many thanks for such a simple and easy to use utility.