### PR TITLE
Make install more configurable

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,3 @@
-
 requirements to build:
 you need these on your system:
 libpng 
@@ -11,6 +10,9 @@ make
 to install 
 run 
 make install
+
+If you want to install to a different directory, use prefix flag like this:
+make prefix=/opt install
 
 Troubleshooting
 If you don't realize how to install splint, remove that row from the Makefile.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@
 ### modular. So this is a simple gnu Makefile...
 ###
 
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+includedir = $(prefix)/include
+datarootdir = $(prefix)/share
+datadir = $(datarootdir)
+mandir = $(datarootdir)/man
+man1dir = $(mandir)/man1
+
 .DELETE_ON_ERROR:
 .PHONY: install clean all
 
@@ -18,8 +27,8 @@ fbgrab.1.gz: fbgrab.1.man
 	$(GZIP) $(GZIPFLAGS) $< > $@
 
 install: fbgrab fbgrab.1.gz
-	install -D -m 0755 fbgrab $(DESTDIR)/usr/bin/fbgrab
-	install -D -m 0644 fbgrab.1.gz $(DESTDIR)/usr/share/man/man1/fbgrab.1.gz
+	install -D -m 0755 fbgrab $(DESTDIR)$(bindir)/fbgrab
+	install -D -m 0644 fbgrab.1.gz $(DESTDIR)$(man1dir)/fbgrab.1.gz
 
 clean:
 	-$(RM) fbgrab fbgrab.1.gz *~ \#*\#

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,9 @@ FBGrab is a framebuffer screenshot program, capturing the linux frambuffer and c
 
 # Releasenotes
 
+## Unreleased
+   $prefix flag was added to allow install to different directory like /opt.
+
 ## New March 25, 2021. Version 1.5
    New in this release is the option to ignore the values in an by the driver incorrectly set alpha channel.
 


### PR DESCRIPTION
Following GNU standard

https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables

This change makes packaging easier, since one does not need to patch the Makefile when it should be installed to different directory. In NixOS, it is installed to `/nix/store/3p7j6l68a6q8d9ygm84c5ydn8g9fs3g6-fbgrab-1.5/bin/fbgrab`.

Please test if it still works for you.