### PR TITLE
PNG generation: fix ignored compression level

### DIFF
--- a/fbgrab.c
+++ b/fbgrab.c
@@ -351,7 +351,7 @@ static void write_PNG(unsigned char *outbuffer, char *filename,
 
     png_init_io(png_ptr, outfile);
 
-    png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);
+    png_set_compression_level(png_ptr, compression);
 
     bit_depth = 8;
     color_type = PNG_COLOR_TYPE_RGB_ALPHA;


### PR DESCRIPTION
User-wanted compression level is printed in verbose traces, but libpng was always given Z_BEST_COMPRESSION (9) instead of this user-wanted compression level.

This resulted in very slow captures (10+ seconds for a 800x480 screenshot on a iMX6ULL board).